### PR TITLE
NEW: adding a new feature to extend the functionality of K.

### DIFF
--- a/ftplugin/sage.vim
+++ b/ftplugin/sage.vim
@@ -4,8 +4,8 @@ if version > 600
   runtime! ftplugin/python.vim
 endif
 
-" Sage settings (from Franco Saliola)
-autocmd Filetype sage set tabstop=2|set shiftwidth=2|set expandtab
+autocmd Filetype sage set tabstop=4|set shiftwidth=4|set expandtab
 autocmd FileType sage set makeprg=sage\ -b\ &&\ sage\ -t\ %
+autocmd FileType sage nnoremap <buffer> <silent> <S-K> :!sage -c "help(<cword>)" \| less <CR><CR>
 
 let b:did_ftplugin = 1


### PR DESCRIPTION
`K` is used to get docstring in vim by default. In the case of sage this not implemented.